### PR TITLE
Fix error rj rs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,9 @@
         "19950512/php-di": "^1.0",
         "php-di/php-di": "^7.0",
         "spatie/crawler": "^8.2",
-        "symfony/dom-crawler": "^7.0",
+        "symfony/dom-crawler": "^6.0|^7.0",
+        "symfony/css-selector": "^6.0|^7.0",
         "guzzlehttp/guzzle": "^7.0",
-        "symfony/css-selector": "^7.0",
         "ext-pdo": "*",
         "predis/predis": "^2.2"
     }

--- a/src/Infraestrutura/Adaptadores/PlataformasCreci/CreciRJPlataformaImplementacao.php
+++ b/src/Infraestrutura/Adaptadores/PlataformasCreci/CreciRJPlataformaImplementacao.php
@@ -52,6 +52,7 @@ class CreciRJPlataformaImplementacao implements PlataformaCreci
 					$respostaHTML = $cadastro;
 					break;
 				}
+				throw new Exception('Ops, Creci não encontrado!');
 			}
 		}
 

--- a/src/Infraestrutura/Adaptadores/PlataformasCreci/CreciRSPlataformaImplementacao.php
+++ b/src/Infraestrutura/Adaptadores/PlataformasCreci/CreciRSPlataformaImplementacao.php
@@ -18,8 +18,9 @@ class CreciRSPlataformaImplementacao implements PlataformaCreci
 	public function __construct(){
 
 		$this->clientHttp = new \GuzzleHttp\Client([
-		    'base_uri' => 'http://www.creci-rs.gov.br',
+		    'base_uri' => 'https://www.creci-rs.gov.br',
 		    'timeout'  => 2.0,
+			'origin' => 'www.creci-rs.gov.br'
 		]);
 	}
 


### PR DESCRIPTION
Adiciona throw após validações não satisfeitas.
Ao buscar pelo creci e a condição `$cadastro->tipo == n and $tipoCreci == 'X'` não for satisfeita ocorre um erro não tratado. 

Adiciona https e origin na request do crecirs.

Modifica packages do composer para suportar o php 8.1.