### PR TITLE
testes com Pestphp

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,5 +21,13 @@
         "guzzlehttp/guzzle": "^7.0",
         "ext-pdo": "*",
         "predis/predis": "^2.2"
+    },
+    "require-dev": {
+        "pestphp/pest": "^3.7"
+    },
+    "config": {
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
+        }
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory suffix="Test.php">./tests</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory suffix=".php">./app</directory>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/tests/Infraestrutura/Adaptadores/PlataformaCreci/Conselho/CreciConselhoPlataformaImplementacaoTest.php
+++ b/tests/Infraestrutura/Adaptadores/PlataformaCreci/Conselho/CreciConselhoPlataformaImplementacaoTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use App\Aplicacao\CasosDeUso\PlataformaCreci;
+use App\Aplicacao\CasosDeUso\EntradaESaida\SaidaConsultarCreciPlataforma;
+use App\Infraestrutura\Adaptadores\PlataformasCreci\Conselho\CreciConselhoPlataformaImplementacao;
+
+test("CreciConselhoPlataformaImplementacao deve implementar a interface PlataformaCreci", function(){
+    $conselho = new CreciConselhoPlataformaImplementacao("PR");
+    expect($conselho)->toBeInstanceOf(CreciConselhoPlataformaImplementacao::class)->toBeInstanceOf(PlataformaCreci::class);
+});
+
+test("Devera retornar o CRECI de um corretor de estado de RO", function(){
+    $conselho = new CreciConselhoPlataformaImplementacao("RO");
+    $numeroInscricao = "2097";
+    $tipoCreci = "F";
+
+    $resposta = $conselho->consultarCreci($numeroInscricao, $tipoCreci);
+
+    expect($resposta)->toBeInstanceOf(SaidaConsultarCreciPlataforma::class);
+    
+    expect($resposta->nomeCompleto)->toBe("IMOVEIS LVF LTDA ME");
+    expect($resposta->situacao)->toBe("Ativo");
+    expect($resposta->estado)->toBe("RO");
+    expect($resposta->numeroDocumento)->toBe("23458090000164");
+    expect($resposta->telefone)->toBe("69993104021");
+})
+->group("PlataformaCreci", "Conselho");
+
+test("Devera lançar uma exception caso o CRECI não exista na região informada.", function(){
+    $conselho = new CreciConselhoPlataformaImplementacao("RO");
+    $numeroInscricao = "123456";
+    $tipoCreci = "F";
+
+    $resposta = $conselho->consultarCreci($numeroInscricao, $tipoCreci);
+
+    expect($resposta)->toBeInstanceOf(SaidaConsultarCreciPlataforma::class);
+})
+->throws('CRECI Inexistente no estado informado')
+->group("PlataformaCreci", "Conselho");


### PR DESCRIPTION
Atualizar pacotes
```bash
composer update
```

Rodar os teste.
```bash
vendor/bin/pest
```
![image](https://github.com/user-attachments/assets/d795451b-948a-4d2c-85ad-a36643ba80b0)

Fiz 2 teste para demonstrar o funcionamento, portanto seria interessante explorar mais situações e simular nos testes
